### PR TITLE
Resolve bug after #118 with !docs listing topics if no input provided

### DIFF
--- a/config/strings.json
+++ b/config/strings.json
@@ -157,7 +157,8 @@
             "Get started with making TryHackMe room",
             "Learn about the TryHackMe room review process",
             "Read about the TryHackMe API",
-            "How to play TryHackMe's King of the Hill (KoTH)"
+            "How to play TryHackMe's King of the Hill (KoTH)",
+            "What rooms should you do? A free guide for beginners"
         ],
         "commands":[
             "",


### PR DESCRIPTION
Left out the string for the new topic in s_strings. If a user was to `!docs` the bot would fail. This is now resolved and re-tested

My apologies for the oversight! It's due to how ugly that cog is, reminding me just now necessary a rewrite is now that HelpJuice have a useable v3 of their API