### PR TITLE
AoC FAQ & Bug Hunter Role Fix

### DIFF
--- a/cogs/faq.py
+++ b/cogs/faq.py
@@ -16,7 +16,7 @@ from libs.embedmaker import officialEmbed
 # Strings and images.
 s_faq = config.get_string("faq")
 img_openvpn = config.get_config("images")["openvpn"]
-
+img_aocfaq = config.get_config("images")["aocfaq"]
 
 ############
 # COG Body #
@@ -54,6 +54,14 @@ class FAQ(commands.Cog):
         response.add_field(name=s_faq["vpnscript"][0], value=s_faq["vpnscript"][1])
 
         await ctx.send(embed=response)
-       
+
+    @commands.command(name="aocfaq", description=s_faq["aocfaq"][0])
+    async def aocfaq(self, ctx):
+        response = officialEmbed()
+
+        response.set_thumbnail(url=(img_aocfaq))
+        response.add_field(name=s_faq["aocfaq"][0], value=s_faq["aocfaq"][1])
+
+        await ctx.send(embed=response)       
 def setup(bot):
     bot.add_cog(FAQ(bot))

--- a/cogs/rolesync.py
+++ b/cogs/rolesync.py
@@ -114,13 +114,13 @@ async def update(member, dm, data, skipUpdatedMessage = False):
         cmdResult += s_verify["contrib_remove"] + "\n"
 
     # Special case: Bug Hunter
-    if level == 999:
+    if level == 998:
         if not has_role(member, id_bughunter):
             await remove_rank_roles(member)
             await add_role(member, id_bughunter)
             cmdResult += s_verify["bughunter_add"] + "\n"
 
-    if level != 999 and has_role(member, id_bughunter):
+    if level != 998 and has_role(member, id_bughunter):
         await remove_bughunter_role(member)
         cmdResult += s_verify["bughunter_remove"] + "\n"
 

--- a/config/config.json
+++ b/config/config.json
@@ -110,7 +110,8 @@
   },
   "images": {
     "openvpn": "https://tryhackme-images.s3.amazonaws.com/room-icons/21367ae689e69d81d71b4591474e62ad.png",
-    "milestone": "https://i.imgur.com/rntbP3y.png"
+    "milestone": "https://i.imgur.com/rntbP3y.png",
+    "aocfaq": "https://styles.redditmedia.com/t5_ygv5g/styles/communityIcon_86434dp6fh061.png"
   },
   "data_files": {
     "gtfobins": "data/gtfobins.json",

--- a/config/strings.json
+++ b/config/strings.json
@@ -38,6 +38,10 @@
         "vpnscript":[
             "Use our VPN troubleshooting script to diagnose common issues!",
             "https://github.com/tryhackme/openvpn-troubleshooting"
+        ],
+        "aocfaq":[
+            "Read the FAQ for AoC 2020",
+            "https://www.reddit.com/r/tryhackme/collection/705c2bce-b424-40e5-8875-ea24539c483f"
         ]
     },
     "feedback":{


### PR DESCRIPTION
Included a link to the AoC 202 FAQ reddit post on request. This is in the "faq" cog alongside `!vpn` and can be used by `!aocfaq`.

The issue with the Bug Hunter role being removed is that the rolesync cog is looking for the API to respond with the user's level being "998" where the actual response is "999".