### PR TITLE
Changed the docs embed to not be inline

### DIFF
--- a/cogs/docs.py
+++ b/cogs/docs.py
@@ -115,7 +115,7 @@ class Docs(commands.Cog):
             response.set_thumbnail(url=(c_docs_picture))
 
             for i in range(1, len(s_commands)):
-                response.add_field(name=s_commands[i], value=s_topics[i])
+                response.add_field(name=s_commands[i], value=s_topics[i], inline=False)
 
             await ctx.send(embed=response)
             return
@@ -163,7 +163,8 @@ class Docs(commands.Cog):
 
         # If anything other then the arguments are provided, say that the topic provided does not exist
         else:
-            response = officialEmbed(title="That topic does not exist!")
+            response = officialEmbed()
+            response.add_field(name="That topic does not exist!", value="Use !docs to list all of the available topics.", inline=False)
             response.set_thumbnail(url=(c_docs_picture))
 
             await ctx.send(embed=response)


### PR DESCRIPTION
to improve readability. Also added a field to the response when an invalid topic is provided

Before:
![image](https://user-images.githubusercontent.com/4163116/112166387-7f09ff80-8be7-11eb-8f34-7504a5bf57e8.png)


After: 
![image](https://user-images.githubusercontent.com/4163116/112166425-85987700-8be7-11eb-9d78-be34987dbf48.png)


Invalid docs response field (before is the first command, after is the second):
![image](https://user-images.githubusercontent.com/4163116/112166519-9cd76480-8be7-11eb-9a97-0725f03a2ed3.png)
