### PR TITLE
Create room help channel when new room is added

### DIFF
--- a/cogs/room.py
+++ b/cogs/room.py
@@ -89,6 +89,11 @@ async def announce_room(channel, json_data, code=None):
 
     # Send messages.
     await channel.send(s_room["newroom"].format(url, announceRole.mention), embed=embed)
+
+    roomCategory = discord.utils.get(channel.guild.categories, name="Recent Releases Help")
+
+    # Create new room channel.
+    await channel.guild.create_text_channel(json_data["title"], category=roomCategory)
  
     # Updates local file.
     with open(c_room_data, "w") as file:


### PR DESCRIPTION
Hey THM,
This is my first (but hopefully not last) contribution to the bot! :D
This is a simple PR, to add a room help channel under its category when a new room is added.
Thanks!
- #!/bin/cat