### PR TITLE
Make the sleep in verify non-blocking

### DIFF
--- a/cogs/rolesync.py
+++ b/cogs/rolesync.py
@@ -189,7 +189,7 @@ class RoleSync(commands.Cog, name="Verifying/Role Assigning Commands"):
             await ctx.message.delete()
 
             msg = await ctx.send(s_verify["error_not_dm"])
-            time.sleep(15)
+            await asyncio.sleep(15)
             await msg.delete()
 
             return


### PR DESCRIPTION
The sleep used when verify was sent in a public channel would block the entire bot for 15 seconds.