### PR TITLE
Fixed checking for sub status

### DIFF
--- a/libs/thm_api.py
+++ b/libs/thm_api.py
@@ -46,7 +46,7 @@ def get_sub_status(username):
     except Exception as err:
         print(f'Other error occurred: {err}')
     else:
-        if "<span>Subscribed</span>" in response.text:
+        if "subscribed-icon" in response.text:
             check = "Yes!"
         else:
             check = "No!"


### PR DESCRIPTION
With the profile page being updated, the old HTML check for if a user was subscribed no longer appears on the page therefore returning everybody's sub value as "No!". I've updated it to now check for the `subscribed-icon` which you can see here:

![image](https://user-images.githubusercontent.com/56607897/178143927-594f329b-e4c4-4253-8e12-4d6a0170c104.png)
